### PR TITLE
Add stopwatch leaderboard with server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # Bunny-game
-Website with the bunny game so Kai can play it at home
+This project now contains a simple stopwatch game with an online leaderboard.
+
+## Running
+
+Use Node.js to start the server:
+
+```bash
+npm start
+```
+
+The game will be available at `http://localhost:3000`. Stop the timer on an
+exact multiple of 5 seconds and submit your name to appear on the shared
+leaderboard stored on the server.

--- a/index.html
+++ b/index.html
@@ -3,32 +3,33 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Multiple-of-5 Second Timer</title>
+  <title>Stopwatch Leaderboard</title>
   <style>
     body { font-family: sans-serif; text-align: center; margin-top: 50px; }
     #timeDisplay { font-size: 48px; margin: 20px; }
     #message { font-size: 24px; margin: 20px; }
-    #bestScore { font-size: 24px; margin: 20px; }
+    #leaderboard { font-size: 20px; margin: 20px; }
     button { font-size: 24px; padding: 10px 20px; cursor: pointer; }
   </style>
 </head>
 <body>
-  <h1>Multiple-of-5 Second Timer</h1>
+  <h1>Stop the Watch on a Multiple of 5</h1>
+  <input id="nameInput" placeholder="Your name" />
   <div id="timeDisplay">0.00</div>
   <button id="controlButton">Start</button>
   <div id="message"></div>
-  <div id="bestScore">Best Score: 0.00</div>
+  <div id="leaderboard"></div>
 
   <script>
     let startTime = null;
     let timerInterval = null;
-    let bestScore = 0;
     let running = false;
 
     const timeDisplay = document.getElementById('timeDisplay');
     const controlButton = document.getElementById('controlButton');
     const message = document.getElementById('message');
-    const bestScoreDisplay = document.getElementById('bestScore');
+    const nameInput = document.getElementById('nameInput');
+    const leaderboard = document.getElementById('leaderboard');
 
     function updateDisplay() {
       const elapsed = (performance.now() - startTime) / 1000;
@@ -54,17 +55,36 @@
       const seconds = parseInt(secStr, 10);
       if (decStr === '00' && seconds % 5 === 0) {
         message.textContent = 'Perfect! You stopped at ' + formatted + ' seconds.';
-        const score = parseFloat(formatted);
-        if (score > bestScore) {
-          bestScore = score;
-          bestScoreDisplay.textContent = 'Best Score: ' + bestScore.toFixed(2);
-        }
+        sendScore(seconds);
       } else {
         message.textContent = 'Miss! You need an exact .00 on a multiple of 5 seconds.';
       }
 
       controlButton.textContent = 'Start';
       running = false;
+    }
+
+    function sendScore(seconds) {
+      const name = nameInput.value || 'Anonymous';
+      fetch('/submit', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, score: seconds })
+      })
+      .then(res => res.json())
+      .then(updateLeaderboard);
+    }
+
+    function updateLeaderboard(scores) {
+      if (!Array.isArray(scores)) return;
+      leaderboard.innerHTML = '<h2>Top Players</h2>' +
+        '<ol>' + scores.map(s => `<li>${s.name} - ${s.score}</li>`).join('') + '</ol>';
+    }
+
+    function loadScores() {
+      fetch('/scores')
+        .then(res => res.json())
+        .then(updateLeaderboard);
     }
 
     controlButton.addEventListener('click', () => {
@@ -74,6 +94,8 @@
         stopTimer();
       }
     });
+
+    loadScores();
   </script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "bunny-game",
+  "version": "1.0.0",
+  "description": "Website with the bunny game so Kai can play it at home",
+  "main": "index.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/scores.json
+++ b/scores.json
@@ -1,0 +1,6 @@
+[
+  {
+    "name": "Tester",
+    "score": 10
+  }
+]

--- a/server.js
+++ b/server.js
@@ -1,0 +1,79 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const url = require('url');
+
+const SCORE_FILE = path.join(__dirname, 'scores.json');
+
+function loadScores() {
+  try {
+    const data = fs.readFileSync(SCORE_FILE, 'utf8');
+    return JSON.parse(data);
+  } catch (err) {
+    return [];
+  }
+}
+
+function saveScores(scores) {
+  fs.writeFileSync(SCORE_FILE, JSON.stringify(scores, null, 2));
+}
+
+function sendFile(res, filePath, contentType) {
+  fs.readFile(filePath, (err, content) => {
+    if (err) {
+      res.writeHead(404);
+      res.end('Not found');
+    } else {
+      res.writeHead(200, { 'Content-Type': contentType });
+      res.end(content);
+    }
+  });
+}
+
+function requestHandler(req, res) {
+  const parsed = url.parse(req.url, true);
+  if (req.method === 'GET' && parsed.pathname === '/scores') {
+    const scores = loadScores().sort((a, b) => b.score - a.score).slice(0, 10);
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify(scores));
+    return;
+  }
+
+  if (req.method === 'POST' && parsed.pathname === '/submit') {
+    let body = '';
+    req.on('data', chunk => body += chunk);
+    req.on('end', () => {
+      try {
+        const data = JSON.parse(body);
+        let scores = loadScores();
+        scores.push({ name: data.name || 'Anonymous', score: data.score });
+        saveScores(scores);
+        scores = scores.sort((a, b) => b.score - a.score).slice(0, 10);
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(scores));
+      } catch (e) {
+        res.writeHead(400);
+        res.end('Invalid data');
+      }
+    });
+    return;
+  }
+
+  // serve static files
+  let filePath = '.' + parsed.pathname;
+  if (filePath === './') filePath = './index.html';
+  const ext = path.extname(filePath).toLowerCase();
+  const mimeTypes = {
+    '.html': 'text/html',
+    '.js': 'application/javascript',
+    '.css': 'text/css',
+    '.json': 'application/json'
+  };
+  const contentType = mimeTypes[ext] || 'text/plain';
+  sendFile(res, filePath, contentType);
+}
+
+const PORT = process.env.PORT || 3000;
+http.createServer(requestHandler).listen(PORT, () => {
+  console.log(`Server running at http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- implement a simple HTTP server using Node builtin modules
- expose `/scores` and `/submit` APIs for the leaderboard
- update the game to allow submitting a name and display the top players
- document running the game server

## Testing
- `node server.js &` *(started server)*
- `curl -s http://localhost:3000/scores`
- `curl -s -X POST http://localhost:3000/submit -H 'Content-Type: application/json' -d '{"name":"Tester","score":10}'`


------
https://chatgpt.com/codex/tasks/task_e_6886508067e483278bd6a69b8571b849